### PR TITLE
Enable equality comparison between Option and Maybe without casting

### DIFF
--- a/SuccincT/Options/Maybe{T}.cs
+++ b/SuccincT/Options/Maybe{T}.cs
@@ -56,7 +56,16 @@ namespace SuccincT.Options
         public T Value => _option.Value;
 
         // ReSharper disable once CanBeReplacedWithTryCastAndCheckForNull
-        public override bool Equals(object obj) => obj is Maybe<T> && _option.Equals(((Maybe<T>) obj)._option);
+        public override bool Equals(object obj)
+        {
+            if (obj is Maybe<T>)
+                return _option.Equals(((Maybe<T>)obj)._option);
+            var objOpt = obj as Option<T>;
+            if (objOpt != null)
+                return _option.Equals(objOpt);
+
+            return false;
+        }
 
         public override int GetHashCode() => _option.GetHashCode();
 

--- a/SuccincT/Options/Option{T}.cs
+++ b/SuccincT/Options/Option{T}.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using SuccincT.Functional;
 using SuccincT.Unions;
 using static SuccincT.Unions.None;
@@ -63,11 +64,22 @@ namespace SuccincT.Options
 
         public override bool Equals(object obj)
         {
-            var testObject = obj as Option<T>;
-            return obj is Option<T> && testObject._union.Equals(_union);
+            if (obj is Option<T>)
+                return (obj as Option<T>)._union.Equals(_union);
+            if (obj is Maybe<T>)
+                return ((Maybe<T>)obj).Equals(this);
+
+            return false;
         }
 
         public override int GetHashCode() => _union.GetHashCode();
+
+        [SuppressMessage("Microsoft.Design", "CA1062:Validate arguments of public methods", MessageId = "0")]
+        public static bool operator ==(Option<T> a, Maybe<T> b) => 
+            a != null ? a.Equals(b) : false;
+        [SuppressMessage("Microsoft.Design", "CA1062:Validate arguments of public methods", MessageId = "0")]
+        public static bool operator !=(Option<T> a, Maybe<T> b) => 
+            a != null ? !(a.Equals(b)) : false;
 
         public static bool operator ==(Option<T> a, object b)
         {

--- a/SuccincTTests/SuccincT/Options/MaybeEqualityTests.cs
+++ b/SuccincTTests/SuccincT/Options/MaybeEqualityTests.cs
@@ -64,5 +64,36 @@ namespace SuccincTTests.SuccincT.Options
             IsTrue(a != b);
             AreNotEqual(a.GetHashCode(), b.GetHashCode());
         }
+
+        [Test]
+        public void OptionAndMaybe_AreEqualWithoutCasting()
+        {
+            var a = Maybe<string>.Some("1234");
+            var b = Option<string>.Some("1234");
+            IsTrue(a.Equals(b));
+            IsTrue(a == b);
+            AreEqual(a, b);
+        }
+
+        [Test]
+        public void EmptyOptionAndMaybe_AreEqualWithoutCasting()
+        {
+            var a = Maybe<string>.None();
+            var b = Option<string>.None();
+            IsTrue(a.Equals(b));
+            IsTrue(a == b);
+            AreEqual(a, b);
+        }
+
+        [Test]
+        public void DifferentValuesInOptionAndMaybe_AreNotEqualWithoutCasting()
+        {
+            var a = Maybe<string>.Some("1234");
+            var b = Option<string>.Some("5678");
+            IsFalse(a.Equals(b));
+            IsFalse(a == b);
+            AreNotEqual(a, b);
+            IsTrue(a != b);
+        }
     }
 }

--- a/SuccincTTests/SuccincT/Options/OptionEqualityTests.cs
+++ b/SuccincTTests/SuccincT/Options/OptionEqualityTests.cs
@@ -63,5 +63,36 @@ namespace SuccincTTests.SuccincT.Options
             IsTrue(a != null);
             IsTrue(null != a);
         }
+
+        [Test]
+        public void OptionAndMaybe_AreEqualWithoutCasting()
+        {
+            var a = Option<string>.Some("1234");
+            var b = Maybe<string>.Some("1234");
+            IsTrue(a.Equals(b));
+            IsTrue(a == b);
+            AreEqual(a, b);
+        }
+
+        [Test]
+        public void EmptyOptionAndMaybe_AreEqualWithoutCasting()
+        {
+            var a = Option<string>.None();
+            var b = Maybe<string>.None();
+            IsTrue(a.Equals(b));
+            IsTrue(a == b);
+            AreEqual(a, b);
+        }
+
+        [Test]
+        public void DifferentOptionAndMaybe_AreNotEqualWithoutCasting()
+        {
+            var a = Option<string>.Some("1234");
+            var b = Maybe<string>.Some("5678");
+            IsFalse(a.Equals(b));
+            IsFalse(a == b);
+            AreNotEqual(a, b);
+            IsTrue(a != b);
+        }
     }
 }


### PR DESCRIPTION
So, I did this one a while ago, and I think I stopped while trying to come up with some kind of optimization for this and then got distracted by a million other things - now I've opened it up again (thanks to your reminder) and I'm honestly not sure what I was hoping to achieve. 

AFAICT it passes the tests I setup, and seems to work as it should - but maybe I've missed something? Anyways, here is the code I have - I'll leave the judgement up to you :)
