### PR TITLE
Fix hashcode typos.

### DIFF
--- a/SuccincT/Unions/Union{T1,T2,T3,T4}.cs
+++ b/SuccincT/Unions/Union{T1,T2,T3,T4}.cs
@@ -45,7 +45,7 @@ namespace SuccincT.Unions
             _hashCodes = new Dictionary<Variant, Func<int>>
             {
                 { Variant.Case1, () => _value1.GetHashCode() },
-                { Variant.Case2, () => _value1.GetHashCode() },
+                { Variant.Case2, () => _value2.GetHashCode() },
                 { Variant.Case3, () => _value3.GetHashCode() },
                 { Variant.Case4, () => _value4.GetHashCode() }
             };

--- a/SuccincT/Unions/Union{T1,T2,T3}.cs
+++ b/SuccincT/Unions/Union{T1,T2,T3}.cs
@@ -39,7 +39,7 @@ namespace SuccincT.Unions
             _hashCodes = new Dictionary<Variant, Func<int>>
             {
                 { Variant.Case1, () => _value1.GetHashCode() },
-                { Variant.Case2, () => _value1.GetHashCode() },
+                { Variant.Case2, () => _value2.GetHashCode() },
                 { Variant.Case3, () => _value3.GetHashCode() }
             };
             _unionsMatch = new Dictionary<Variant, Func<Union<T1, T2, T3>, bool>>


### PR DESCRIPTION
In two unions, value1 is used to calculate the hashcode of value2.