### PR TITLE
Option Extensions

### DIFF
--- a/SuccincT/Options/OptionExtensions.cs
+++ b/SuccincT/Options/OptionExtensions.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using SuccincT.Functional;
+
+namespace SuccincT.Options
+{
+    public static class OptionExtensions
+    {
+        public static Option<TOutput> Map<TInput, TOutput>(this Option<TInput> input, Func<TInput, TOutput> f)
+        {
+            return
+                input.Match<Option<TOutput>>()
+                    .Some().Do(x => f(x).Into(Option<TOutput>.Some))
+                    .None().Do(Option<TOutput>.None())
+                    .Result();
+        }
+
+        public static Option<T> Or<T>(this Option<T> option, Option<T> anotherOption)
+        {
+            return option.HasValue ? option : anotherOption;
+        }
+
+        public static Option<T> Or<T>(this Option<T> option, Func<Option<T>> lazyAnotherOption)
+        {
+            return option.HasValue ? option : lazyAnotherOption();
+        }
+
+        public static Option<T> Flatten<T>(this Option<Option<T>> option)
+        {
+            return
+                option.Match<Option<T>>()
+                    .Some().Do(x => x)
+                    .None().Do(Option<T>.None())
+                    .Result();
+        }
+
+        public static IEnumerable<T> Choose<T>(this IEnumerable<Option<T>> options)
+        {
+            return options.Where(x => x.HasValue).Select(x => x.Value);
+        }
+    }
+}

--- a/SuccincT/Options/OptionExtensionsForDictionaryType.cs
+++ b/SuccincT/Options/OptionExtensionsForDictionaryType.cs
@@ -4,7 +4,7 @@ namespace SuccincT.Options
 {
     public static class OptionExtensionsForDictionaryType
     {
-        public static Option<TValue> TryGetValue<TKey, TValue>(this Dictionary<TKey, TValue> dictionary, TKey key)
+        public static Option<TValue> TryGetValue<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key)
         {
             TValue value;
             return dictionary.TryGetValue(key, out value) ? Option<TValue>.Some(value) : Option<TValue>.None();

--- a/SuccincT/Options/OptionExtensionsForGeneralTypes.cs
+++ b/SuccincT/Options/OptionExtensionsForGeneralTypes.cs
@@ -1,0 +1,17 @@
+﻿using SuccincT.Functional;
+
+namespace SuccincT.Options
+{
+    public static class OptionExtensionsForGeneralTypes
+    {
+        public static Option<T> ToOption<T>(this T obj)
+        {
+            return obj != null ? obj.Into(Option<T>.Some) : Option<T>.None();
+        }
+
+        public static T? AsNullable<T>(this Option<T> option) where T : struct
+        {
+            return option.HasValue ? option.Value : (T?) null;
+        }
+    }
+}

--- a/SuccincT/SuccincT.csproj
+++ b/SuccincT/SuccincT.csproj
@@ -59,7 +59,9 @@
     <Compile Include="CompilationTargetHandler.cs" />
     <Compile Include="Functional\ActionExtensions.cs" />
     <Compile Include="Functional\Either.cs" />
+    <Compile Include="Options\OptionExtensions.cs" />
     <Compile Include="Options\OptionExtensionsForDictionaryType.cs" />
+    <Compile Include="Options\OptionExtensionsForGeneralTypes.cs" />
     <Compile Include="PatternMatchers\Any.cs" />
     <Compile Include="Functional\ConsEnumerable.cs" />
     <Compile Include="Functional\ConsListBuilderEnumerator.cs" />

--- a/SuccincTTests/SuccincT/Options/OptionExtensionsForGeneralTypesTests.cs
+++ b/SuccincTTests/SuccincT/Options/OptionExtensionsForGeneralTypesTests.cs
@@ -1,0 +1,64 @@
+﻿using NUnit.Framework;
+using SuccincT.Options;
+
+namespace SuccincTTests.SuccincT.Options
+{
+    [TestFixture]
+    public sealed class OptionExtensionsForGeneralTypesTests
+    {
+        [Test]
+        public void WhenObjectIsNotNull_ToOptionReturnsValue()
+        {
+            var obj = 10;
+            var opt = obj.ToOption();
+            Assert.IsNotNull(opt);
+            Assert.IsTrue(opt.HasValue);
+            Assert.AreEqual(10, opt.Value);
+        }
+
+        [Test]
+        public void WhenObjectIsNull_ToOptionReturnsNone()
+        {
+            var obj = (object) null;
+            var opt = obj.ToOption();
+            Assert.IsNotNull(opt);
+            Assert.IsFalse(opt.HasValue);
+        }
+
+        [Test]
+        public void WhenNullableStructHasValue_ToOptionReturnsValue()
+        {
+            int? obj = 15;
+            var opt = obj.ToOption();
+            Assert.IsNotNull(opt);
+            Assert.IsTrue(opt.HasValue);
+            Assert.AreEqual(15, opt.Value);
+        }
+
+        [Test]
+        public void WhenNullableStructHasNoValue_ToOptionReturnsNone()
+        {
+            int? obj = null;
+            var opt = obj.ToOption();
+            Assert.IsNotNull(opt);
+            Assert.IsFalse(opt.HasValue);
+        }
+
+        [Test]
+        public void WhenOptionHasValue_AsNullableReturnsThatValue()
+        {
+            var opt = Option<int>.Some(400);
+            var val = opt.AsNullable();
+            Assert.IsNotNull(val);
+            Assert.AreEqual(400, val.Value);
+        }
+
+        [Test]
+        public void WhenOptionHasNoValue_AsNullableReturnsNull()
+        {
+            var opt = Option<bool>.None();
+            var val = opt.AsNullable();
+            Assert.IsNull(val);
+        }
+    }
+}

--- a/SuccincTTests/SuccincT/Options/OptionExtensionsTests.cs
+++ b/SuccincTTests/SuccincT/Options/OptionExtensionsTests.cs
@@ -1,0 +1,127 @@
+﻿using System;
+using NUnit.Framework;
+using SuccincT.Functional;
+using SuccincT.Options;
+
+namespace SuccincTTests.SuccincT.Options
+{
+    [TestFixture]
+    public sealed class OptionExtensionsTests
+    {
+        [Test]
+        public void WhenOptionHasValue_MapAppliesFuncToThatValueAndReturnsNewOptionWithThatValue()
+        {
+            var opt = Option<int>.Some(50);
+            var mappedOpt = opt.Map(x => x * x);
+            Assert.IsTrue(mappedOpt.HasValue);
+            Assert.AreEqual(2500, mappedOpt.Value);
+        }
+
+        [Test]
+        public void WhenOptionHasNoValue_MapReturnsNone()
+        {
+            var opt = Option<bool>.None();
+            var mappedOpt = opt.Map(x => x ? 300 : 100);
+            Assert.IsFalse(mappedOpt.HasValue);
+        }
+
+        [Test]
+        public void WhenOptionHasValue_OrReturnsThatOption()
+        {
+            var opt1 = Option<int>.Some(10);
+            var opt2 = Option<int>.Some(50);
+            var res = opt1.Or(opt2);
+            Assert.IsTrue(res.HasValue);
+            Assert.AreEqual(10, res.Value);
+        }
+
+        [Test]
+        public void WhenOptionHasNoValue_OrReturnsAnotherOption()
+        {
+            var opt1 = Option<int>.None();
+            var opt2 = Option<int>.Some(50);
+            var res = opt1.Or(opt2);
+            Assert.IsTrue(res.HasValue);
+            Assert.AreEqual(50, res.Value);
+        }
+
+        [Test]
+        public void WhenBothOptionsHaveNoValue_OrReturnsNone()
+        {
+            var opt1 = Option<int>.None();
+            var opt2 = Option<int>.None();
+            var res = opt1.Or(opt2);
+            Assert.IsFalse(res.HasValue);
+        }
+
+        [Test]
+        public void WhenOptionHasValue_LazyOrReturnsThatOptionAndDoesNotComputeAnotherOption()
+        {
+            var opt1 = Option<string>.Some("OK");
+            Func<Option<string>> opt2 = () => { throw new InvalidOperationException(); };
+            var res = opt1.Or(opt2);
+            Assert.IsTrue(res.HasValue);
+            Assert.AreEqual("OK", res.Value);
+        }
+
+        [Test]
+        public void WhenOptionHasNoValue_LazyOrComputesAndReturnsAnotherOption()
+        {
+            var opt1 = Option<string>.None();
+            Func<Option<string>> opt2 = () => Option<string>.Some("OK too");
+            var res = opt1.Or(opt2);
+            Assert.IsTrue(res.HasValue);
+            Assert.AreEqual("OK too", res.Value);
+        }
+
+        [Test]
+        public void WhenBothOptionsHaveNoValue_LazyOrReturnsNone()
+        {
+            var opt1 = Option<string>.None();
+            Func<Option<string>> opt2 = Option<string>.None;
+            var res = opt1.Or(opt2);
+            Assert.IsFalse(res.HasValue);
+        }
+
+        [Test]
+        public void WhenOptionHasValue_FlattenReturnsUnderlyingOption()
+        {
+            var opt = Option<int>.Some(50).Into(Option<Option<int>>.Some);
+            var flat = opt.Flatten();
+            Assert.IsTrue(flat.HasValue);
+            Assert.AreEqual(50, flat.Value);
+        }
+
+        [Test]
+        public void WhenOptionHasNoValue_FlattenReturnsNone()
+        {
+            var opt = Option<Option<int>>.None();
+            var flat = opt.Flatten();
+            Assert.IsFalse(flat.HasValue);
+        }
+
+        [Test]
+        public void WhenUnderlyingOptionHasNoValue_FlattenReturnsNone()
+        {
+            var opt = Option<int>.None().Into(Option<Option<int>>.Some);
+            var flat = opt.Flatten();
+            Assert.IsFalse(flat.HasValue);
+        }
+
+        [Test]
+        public void WhenThereAreAnyOptionsWithValuesInCollection_ChooseReturnsThoseValuesAsAnotherCollection()
+        {
+            var opts = new[] { Option<int>.None(), Option<int>.Some(10), Option<int>.Some(20), Option<int>.None(), Option<int>.Some(30), Option<int>.None() };
+            var chosenOpts = opts.Choose();
+            CollectionAssert.AreEqual(new [] { 10, 20, 30 }, chosenOpts);
+        }
+
+        [Test]
+        public void WhenThereAreNoOptionsWithValuesInCollection_ChooseReturnsEmptyCollection()
+        {
+            var opts = new[] { Option<bool>.None(), Option<bool>.None() };
+            var chosenOpts = opts.Choose();
+            CollectionAssert.IsEmpty(chosenOpts);
+        }
+    }
+}

--- a/SuccincTTests/SuccincTTests.csproj
+++ b/SuccincTTests/SuccincTTests.csproj
@@ -90,6 +90,8 @@
     <Compile Include="SuccincT\JSON\UnionOf2ConverterTests.cs" />
     <Compile Include="SuccincT\Options\ElementAtOrNoneTests.cs" />
     <Compile Include="SuccincT\Options\MaybeEqualityTests.cs" />
+    <Compile Include="SuccincT\Options\OptionExtensionsForGeneralTypesTests.cs" />
+    <Compile Include="SuccincT\Options\OptionExtensionsTests.cs" />
     <Compile Include="SuccincT\Options\OptionIgnoreElseTests.cs" />
     <Compile Include="SuccincT\Options\MaybeTests.cs" />
     <Compile Include="SuccincT\Options\SingleOrNoneTests.cs" />


### PR DESCRIPTION
Added a couple of extensions for Options.

1) ToOption is a shortcut to convert nullable values that come from external APIs.

2) Map is a way to apply a given function to the value of Option.

3) AsNullable is a shortcut to convert Option with struct value into a nullable struct that external APIs may use.

4) Or is a way to allow expressions like F1() ?? F2() ?? F3() to be used in the world of Options.

5) Flatten is a way to extract a nested Option, which is useful when you operate on a collection of Options with stuff like TryFirst.

6) Choose is a way to extract values from a collection of Options.