### PR TITLE
Option<T>.None Optimization Fix

### DIFF
--- a/SuccincT/Options/Option{T}.cs
+++ b/SuccincT/Options/Option{T}.cs
@@ -12,7 +12,7 @@ namespace SuccincT.Options
     /// </summary>
     public sealed class Option<T>
     {
-        private static readonly Option<T> _none = new Option<T>(unit);
+        private static readonly Option<T> NoneInstance = new Option<T>(unit);
         private readonly Union<T, None> _union;
 
         // ReSharper disable once UnusedParameter.Local - unit param used to
@@ -31,7 +31,7 @@ namespace SuccincT.Options
         /// <summary>
         /// Creates an instance of an option with no value.
         /// </summary>
-        public static Option<T> None() => _none;
+        public static Option<T> None() => NoneInstance;
 
         /// <summary>
         /// Creates an instance of option with the specified value.

--- a/SuccincT/Options/Option{T}.cs
+++ b/SuccincT/Options/Option{T}.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using SuccincT.Functional;
 using SuccincT.Unions;
@@ -13,7 +12,7 @@ namespace SuccincT.Options
     /// </summary>
     public sealed class Option<T>
     {
-        private static readonly ConcurrentDictionary<Type, Option<T>> OptionNoneCache = new ConcurrentDictionary<Type, Option<T>>();
+        private static readonly Option<T> _none = new Option<T>(unit);
         private readonly Union<T, None> _union;
 
         // ReSharper disable once UnusedParameter.Local - unit param used to
@@ -32,7 +31,7 @@ namespace SuccincT.Options
         /// <summary>
         /// Creates an instance of an option with no value.
         /// </summary>
-        public static Option<T> None() => OptionNoneCache.GetOrAdd(typeof(T), new Option<T>(unit));
+        public static Option<T> None() => _none;
 
         /// <summary>
         /// Creates an instance of option with the specified value.

--- a/SuccincTTests/SuccincT/Options/OptionEqualityTests.cs
+++ b/SuccincTTests/SuccincT/Options/OptionEqualityTests.cs
@@ -121,5 +121,13 @@ namespace SuccincTTests.SuccincT.Options
             var b = Option<string>.None();
             AreSame(a, b);
         }
+
+        [Test]
+        public void EmptyOptionsOfDifferentTypes_AreNotReferentiallyEqual()
+        {
+            var a = Option<string>.None();
+            var b = Option<int>.None();
+            AreNotSame(a, b);
+        }
     }
 }


### PR DESCRIPTION
Simplified caching of Option<T>.None() value due to the fact that each generic type instance contains it's own static field instance, so there is no point to keep a dictionary that will eventually store a single value.