### PR TITLE
Accessing Union values directly.

### DIFF
--- a/src/SuccincT/Unions/Union{T1,T2,T3,T4}.cs
+++ b/src/SuccincT/Unions/Union{T1,T2,T3,T4}.cs
@@ -65,6 +65,27 @@ namespace SuccincT.Unions
         public T2 Case2 => Case == Variant.Case2 ? _value2 : throw new InvalidCaseException(Variant.Case2, Case);
         public T3 Case3 => Case == Variant.Case3 ? _value3 : throw new InvalidCaseException(Variant.Case3, Case);
         public T4 Case4 => Case == Variant.Case4 ? _value4 : throw new InvalidCaseException(Variant.Case4, Case);
+        public TResult Value<TResult>()
+        {
+            if (typeof(TResult) == typeof(T1))
+            {
+                return (TResult)(object)Case1;
+            }
+            if (typeof(TResult) == typeof(T2))
+            {
+                return (TResult)(object)Case2;
+            }
+            if (typeof(TResult) == typeof(T3))
+            {
+                return (TResult)(object)Case3;
+            }
+            if (typeof(TResult) == typeof(T4))
+            {
+                return (TResult)(object)Case4;
+            }
+
+            throw new InvalidCaseOfTypeException(typeof(TResult));
+        }
 
         public IUnionFuncPatternMatcher<T1, T2, T3, T4, TResult> Match<TResult>() =>
             new UnionPatternMatcher<T1, T2, T3, T4, TResult>(this);

--- a/src/SuccincT/Unions/Union{T1,T2,T3}.cs
+++ b/src/SuccincT/Unions/Union{T1,T2,T3}.cs
@@ -57,6 +57,23 @@ namespace SuccincT.Unions
         public T1 Case1 => Case == Variant.Case1 ? _value1 : throw new InvalidCaseException(Variant.Case1, Case);
         public T2 Case2 => Case == Variant.Case2 ? _value2 : throw new InvalidCaseException(Variant.Case2, Case);
         public T3 Case3 => Case == Variant.Case3 ? _value3 : throw new InvalidCaseException(Variant.Case3, Case);
+        public TResult Value<TResult>()
+        {
+            if (typeof(TResult) == typeof(T1))
+            {
+                return (TResult)(object)Case1;
+            }
+            if (typeof(TResult) == typeof(T2))
+            {
+                return (TResult)(object)Case2;
+            }
+            if (typeof(TResult) == typeof(T3))
+            {
+                return (TResult)(object)Case3;
+            }
+
+            throw new InvalidCaseOfTypeException(typeof(TResult));
+        }
 
         public IUnionFuncPatternMatcher<T1, T2, T3, TResult> Match<TResult>() => 
             new UnionFuncPatternMatcher<T1, T2, T3, TResult>(this);

--- a/src/SuccincT/Unions/Union{T1,T2}.cs
+++ b/src/SuccincT/Unions/Union{T1,T2}.cs
@@ -1,4 +1,5 @@
-﻿using SuccincT.Functional;
+﻿using System;
+using SuccincT.Functional;
 using SuccincT.Unions.PatternMatchers;
 using static SuccincT.Functional.Unit;
 
@@ -32,6 +33,20 @@ namespace SuccincT.Unions
 
         public T1 Case1 => Case == Variant.Case1 ? _value1 : throw new InvalidCaseException(Variant.Case1, Case);
         public T2 Case2 => Case == Variant.Case2 ? _value2 : throw new InvalidCaseException(Variant.Case2, Case);
+
+        public TResult Value<TResult>()
+        {
+            if (typeof(TResult) == typeof(T1))
+            {
+                return (TResult)(object)Case1;
+            }
+            if (typeof(TResult) == typeof(T2))
+            {
+                return (TResult)(object)Case2;
+            }
+
+            throw new InvalidCaseOfTypeException(typeof(TResult));
+        }
 
         public IUnionFuncPatternMatcher<T1, T2, TResult> Match<TResult>() =>
             new UnionPatternMatcher<T1, T2, TResult>(this);

--- a/tests/SuccincT.Tests/SuccincT/Unions/UnionT1T2DirectValueTests.cs
+++ b/tests/SuccincT.Tests/SuccincT/Unions/UnionT1T2DirectValueTests.cs
@@ -1,0 +1,32 @@
+using NUnit.Framework;
+using SuccincT.Unions;
+using static NUnit.Framework.Assert;
+
+namespace SuccincTTests.SuccincT.Unions
+{
+    public sealed class UnionT1T2DirectValueTests
+    {
+        [Test]
+        public void UnionWithT1_ValueMatchesCorrectly()
+        {
+            var union = new Union<int, string>(1);
+            var result = union.Value<int>();
+            AreEqual(1, result);
+        }
+
+        [Test]
+        public void UnionWithT2_ValueMatchesCorrectly()
+        {
+            var union = new Union<int, string>("string");
+            var result = union.Value<string>();
+            AreEqual("string", result);
+        }
+
+        [Test]
+        public void UnionT1T2WithInvalidTypeValue_ThrowsException()
+        {
+            var union = new Union<int, string>(2);
+            Throws<InvalidCaseOfTypeException>(() => union.Value<float>());
+        }
+    }
+}

--- a/tests/SuccincT.Tests/SuccincT/Unions/UnionT1T2T3DirectValueTests.cs
+++ b/tests/SuccincT.Tests/SuccincT/Unions/UnionT1T2T3DirectValueTests.cs
@@ -1,0 +1,42 @@
+using NUnit.Framework;
+using SuccincT.Unions;
+using static NUnit.Framework.Assert;
+
+namespace SuccincTTests.SuccincT.Unions
+{
+    public sealed class UnionT1T2T3DirectValueTests
+    {
+        private enum Plants { Rose, Tree, Weed }
+
+        [Test]
+        public void UnionWithT1_ValueMatchesCorrectly()
+        {
+            var union = new Union<int, string, Plants>(1);
+            var result = union.Value<int>();
+            AreEqual(1, result);
+        }
+
+        [Test]
+        public void UnionWithT2_ValueMatchesCorrectly()
+        {
+            var union = new Union<int, string, Plants>("string");
+            var result = union.Value<string>();
+            AreEqual("string", result);
+        }
+
+        [Test]
+        public void UnionWithT3_ValueMatchesCorrectly()
+        {
+            var union = new Union<int, string, Plants>(Plants.Rose);
+            var result = union.Value<Plants>();
+            AreEqual(Plants.Rose, result);
+        }
+
+        [Test]
+        public void UnionT1T2T3WithInvalidTypeValue_ThrowsException()
+        {
+            var union = new Union<int, string, Plants>(2);
+            Throws<InvalidCaseOfTypeException>(() => union.Value<float>());
+        }
+    }
+}

--- a/tests/SuccincT.Tests/SuccincT/Unions/UnionT1T2T3T4DirectValueTests.cs
+++ b/tests/SuccincT.Tests/SuccincT/Unions/UnionT1T2T3T4DirectValueTests.cs
@@ -1,0 +1,51 @@
+using NUnit.Framework;
+using SuccincT.Unions;
+using static NUnit.Framework.Assert;
+
+namespace SuccincTTests.SuccincT.Unions
+{
+    public sealed class UnionT1T2T3T4DirectValueTests
+    {
+        private enum Plants { Rose, Tree, Weed }
+        private enum Foods { Cheese, Cake, Chocolate }
+
+        [Test]
+        public void UnionWithT1_ValueMatchesCorrectly()
+        {
+            var union = new Union<int, string, Plants, Foods>(1);
+            var result = union.Value<int>();
+            AreEqual(1, result);
+        }
+
+        [Test]
+        public void UnionWithT2_ValueMatchesCorrectly()
+        {
+            var union = new Union<int, string, Plants, Foods>("string");
+            var result = union.Value<string>();
+            AreEqual("string", result);
+        }
+
+        [Test]
+        public void UnionWithT3_ValueMatchesCorrectly()
+        {
+            var union = new Union<int, string, Plants, Foods>(Plants.Rose);
+            var result = union.Value<Plants>();
+            AreEqual(Plants.Rose, result);
+        }
+
+        [Test]
+        public void UnionWithT4_ValueMatchesCorrectly()
+        {
+            var union = new Union<int, string, Plants, Foods>(Foods.Cake);
+            var result = union.Value<Foods>();
+            AreEqual(Foods.Cake, result);
+        }
+
+        [Test]
+        public void UnionT1T2T3WithInvalidTypeValue_ThrowsException()
+        {
+            var union = new Union<int, string, Plants>(2);
+            Throws<InvalidCaseOfTypeException>(() => union.Value<float>());
+        }
+    }
+}


### PR DESCRIPTION
Similar to how we can imperatively get values from options via its
value property, it's useful to be able to imperatively get values from
unions.