### PR TITLE
Add implicit conversion from value to Maybe

### DIFF
--- a/src/SuccincT/Options/Maybe{T}.cs
+++ b/src/SuccincT/Options/Maybe{T}.cs
@@ -79,12 +79,13 @@ namespace SuccincT.Options
 
         public override int GetHashCode() => Option.GetHashCode();
 
-        public static bool operator ==(Maybe<T> a,Option<T> b) => a.Option == b;
+        public static bool operator ==(Maybe<T> a, Option<T> b) => a.Option == b;
 
         public static bool operator !=(Maybe<T> a, Option<T> b) => a.Option != b;
 
         internal Option<T> Option { get; }
 
+        public static implicit operator Maybe<T>(T value) => new Maybe<T>(value);
         public static implicit operator Maybe<T>(Option<T> option) => new Maybe<T>(option);
 
         public void Deconstruct(out bool hasValue, out T value) =>

--- a/tests/SuccincT.Tests/SuccincT/Options/MaybeTests.cs
+++ b/tests/SuccincT.Tests/SuccincT/Options/MaybeTests.cs
@@ -1,9 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using SuccincT.Options;
 using SuccincT.Parsers;
 using SuccincT.PatternMatchers;
+using System;
+using System.Collections.Generic;
 using static NUnit.Framework.Assert;
 using static SuccincT.Functional.Unit;
 
@@ -200,7 +200,7 @@ namespace SuccincTTests.SuccincT.Options
         [Test]
         public void IEnumerableExtensions_CanBeUsedWithMaybe()
         {
-            var list = new List<int> {1, 2, 3, 4};
+            var list = new List<int> { 1, 2, 3, 4 };
             Maybe<int> match = list.TryFirst(item => item == 2);
             Maybe<int> noMatch = list.TryElementAt(5);
 
@@ -238,6 +238,13 @@ namespace SuccincTTests.SuccincT.Options
         {
             var option = Maybe<int>.None();
             AreEqual(0, option.ValueOrDefault);
+        }
+
+        [Test]
+        public void WhenImplicitlyConverting_ValueEqualsProvidedParameter()
+        {
+            Maybe<int> maybe = 3;
+            AreEqual(3, maybe.Value);
         }
     }
 }

--- a/tests/SuccincT.Tests/SuccincT/Options/OptionTests.cs
+++ b/tests/SuccincT.Tests/SuccincT/Options/OptionTests.cs
@@ -1,7 +1,7 @@
-﻿using System;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using SuccincT.Options;
 using SuccincT.PatternMatchers;
+using System;
 using static NUnit.Framework.Assert;
 using static SuccincT.Functional.Unit;
 
@@ -215,6 +215,13 @@ namespace SuccincTTests.SuccincT.Options
         {
             var option = Option<int>.None();
             AreEqual(0, option.ValueOrDefault);
+        }
+
+        [Test]
+        public void WhenImplicitlyConverting_ValueEqualsProvidedParameter()
+        {
+            Option<int> option = 3;
+            AreEqual(3, option.Value);
         }
     }
 }


### PR DESCRIPTION
Fixes a gap between what is described in the wiki (https://github.com/DavidArno/SuccincT/wiki/Maybe_T_#construction) and the actual behavior (compilation error when trying to implicitly convert a value to a Maybe).
Added the unit test that checks this behavior on both Option and Maybe.