### PR TITLE
Adds HasValue method to unions

### DIFF
--- a/src/SuccincT/Unions/Union{T1,T2,T3,T4}.cs
+++ b/src/SuccincT/Unions/Union{T1,T2,T3,T4}.cs
@@ -77,6 +77,23 @@ namespace SuccincT.Unions
                 default: throw new InvalidCaseOfTypeException(typeof(TResult));
             }
         }
+        
+        public bool HasValue<TResult>()
+        {
+            switch (Case)
+            {
+                case Variant.Case1:
+                    return _value1.GetType() == typeof(TResult);
+                case Variant.Case2:
+                    return _value2.GetType() == typeof(TResult);
+                case Variant.Case3:
+                    return _value3.GetType() == typeof(TResult);
+                case Variant.Case4:
+                    return _value4.GetType() == typeof(TResult);
+            }
+
+            return false;
+        }
 
         public IUnionFuncPatternMatcher<T1, T2, T3, T4, TResult> Match<TResult>() =>
             new UnionPatternMatcher<T1, T2, T3, T4, TResult>(this);

--- a/src/SuccincT/Unions/Union{T1,T2,T3}.cs
+++ b/src/SuccincT/Unions/Union{T1,T2,T3}.cs
@@ -68,6 +68,21 @@ namespace SuccincT.Unions
                 default: throw new InvalidCaseOfTypeException(typeof(TResult));
             }
         }
+        
+        public bool HasValue<TResult>()
+        {
+            switch (Case)
+            {
+                case Variant.Case1:
+                    return _value1.GetType() == typeof(TResult);
+                case Variant.Case2:
+                    return _value2.GetType() == typeof(TResult);
+                case Variant.Case3:
+                    return _value3.GetType() == typeof(TResult);
+            }
+
+            return false;
+        }
 
         public IUnionFuncPatternMatcher<T1, T2, T3, TResult> Match<TResult>() =>
             new UnionFuncPatternMatcher<T1, T2, T3, TResult>(this);

--- a/src/SuccincT/Unions/Union{T1,T2}.cs
+++ b/src/SuccincT/Unions/Union{T1,T2}.cs
@@ -43,6 +43,19 @@ namespace SuccincT.Unions
             }
         }
 
+        public bool HasValue<TResult>()
+        {
+            switch (Case)
+            {
+                case Variant.Case1:
+                    return _value1.GetType() == typeof(TResult);
+                case Variant.Case2:
+                    return _value2.GetType() == typeof(TResult);
+            }
+
+            return false;
+        }
+
         public IUnionFuncPatternMatcher<T1, T2, TResult> Match<TResult>() =>
             new UnionPatternMatcher<T1, T2, TResult>(this);
 

--- a/tests/SuccincT.Tests/SuccincT/Unions/UnionT1T2DirectValueTests.cs
+++ b/tests/SuccincT.Tests/SuccincT/Unions/UnionT1T2DirectValueTests.cs
@@ -28,5 +28,29 @@ namespace SuccincTTests.SuccincT.Unions
             var union = new Union<int, string>(2);
             Throws<InvalidCaseOfTypeException>(() => union.Value<float>());
         }
+
+        [Test]
+        public void UnionT1HasValueTest_ReturnsTrue()
+        {
+            var union = new Union<int, string>(2);
+            var hasInteger = union.HasValue<int>();
+            IsTrue(hasInteger);
+        }
+        
+        [Test]
+        public void UnionT1T2HasValueTest_ReturnsFalse()
+        {
+            var union = new Union<int, string>(2);
+            var hasInteger = union.HasValue<string>();
+            IsFalse(hasInteger);
+        }
+        
+        [Test]
+        public void UnionT1T2HasValueTest_ReturnsFalseAndDoesNotThrowExceptionTypeNotInUnion()
+        {
+            var union = new Union<int, string>(2);
+            var hasBool = union.HasValue<bool>();
+            IsFalse(hasBool);
+        }
     }
 }

--- a/tests/SuccincT.Tests/SuccincT/Unions/UnionT1T2T3DirectValueTests.cs
+++ b/tests/SuccincT.Tests/SuccincT/Unions/UnionT1T2T3DirectValueTests.cs
@@ -38,5 +38,29 @@ namespace SuccincTTests.SuccincT.Unions
             var union = new Union<int, string, Plants>(2);
             Throws<InvalidCaseOfTypeException>(() => union.Value<float>());
         }
+        
+        [Test]
+        public void UnionT1HasValueTest_ReturnsTrue()
+        {
+            var union = new Union<int, string, Plants>(2);
+            var hasInteger = union.HasValue<int>();
+            IsTrue(hasInteger);
+        }
+        
+        [Test]
+        public void UnionT1T2T3HasValueTest_ReturnsFalse()
+        {
+            var union = new Union<int, string, Plants>(2);
+            var hasInteger = union.HasValue<Plants>();
+            IsFalse(hasInteger);
+        }
+        
+        [Test]
+        public void UnionT1T2T3HasValueTest_ReturnsFalseAndDoesNotThrowExceptionTypeNotInUnion()
+        {
+            var union = new Union<int, string, Plants>(2);
+            var hasBool = union.HasValue<bool>();
+            IsFalse(hasBool);
+        }
     }
 }

--- a/tests/SuccincT.Tests/SuccincT/Unions/UnionT1T2T3T4DirectValueTests.cs
+++ b/tests/SuccincT.Tests/SuccincT/Unions/UnionT1T2T3T4DirectValueTests.cs
@@ -42,10 +42,34 @@ namespace SuccincTTests.SuccincT.Unions
         }
 
         [Test]
-        public void UnionT1T2T3WithInvalidTypeValue_ThrowsException()
+        public void UnionT1T2T3T4WithInvalidTypeValue_ThrowsException()
         {
             var union = new Union<int, string, Plants, Foods>(2);
             Throws<InvalidCaseOfTypeException>(() => union.Value<float>());
+        }
+        
+        [Test]
+        public void UnionT1HasValueTest_ReturnsTrue()
+        {
+            var union = new Union<int, string, Plants, Foods>(2);
+            var hasInteger = union.HasValue<int>();
+            IsTrue(hasInteger);
+        }
+        
+        [Test]
+        public void UnionT1T2T3T4HasValueTest_ReturnsFalse()
+        {
+            var union = new Union<int, string, Plants, Foods>(2);
+            var hasInteger = union.HasValue<Plants>();
+            IsFalse(hasInteger);
+        }
+        
+        [Test]
+        public void UnionT1T2T3T4HasValueTest_ReturnsFalseAndDoesNotThrowExceptionTypeNotInUnion()
+        {
+            var union = new Union<int, string, Plants, Foods>(2);
+            var hasBool = union.HasValue<bool>();
+            IsFalse(hasBool);
         }
     }
 }


### PR DESCRIPTION
Add a method HasValue<TResult> to unions. This allows for imperative checking that the union's selected case is of a certain type without having to reference Case1, Case2, etc... Also avoids using exceptions for control flow.