### PR TITLE
Add enum parser for enums that are mapped to chars

### DIFF
--- a/src/SuccincT/Parsers/EnumCharParser.cs
+++ b/src/SuccincT/Parsers/EnumCharParser.cs
@@ -1,0 +1,32 @@
+﻿using SuccincT.Options;
+using System;
+
+namespace SuccincT.Parsers
+{
+    /// <summary>
+    /// An enum parser that handles enums that are mapped to chars
+    /// </summary>
+    public static class EnumCharParser
+    {
+        /// <summary>
+        /// Parses an enum that is mapped to a char
+        /// </summary>
+        /// <typeparam name="T">Enum type</typeparam>
+        /// <param name="source">source char</param>
+        /// <returns>Option for the parsed enum</returns>
+        /// <exception cref="T:System.ArgumentExeption">If T is not of an Enum Type</exception>
+        public static Option<T> TryParsEnum<T>(this char source) where T : struct
+        {
+            var sourceAsInt = (int)source;
+
+            // Since TryParse will return true even for ints that don't
+            // correspond to valid enum values, need to check using IsDefined first
+            if (!Enum.IsDefined(typeof(T), sourceAsInt))
+            {
+                return Option<T>.None();
+            }
+
+            return sourceAsInt.ToString().TryParseEnum<T>();
+        }
+    }
+}

--- a/tests/SuccincT.Tests/SuccincT/EnumParsers/EnumCharParserTests.cs
+++ b/tests/SuccincT.Tests/SuccincT/EnumParsers/EnumCharParserTests.cs
@@ -1,0 +1,80 @@
+﻿using NUnit.Framework;
+using System;
+using SuccincT.Options;
+using SuccincT.Parsers;
+using static NUnit.Framework.Assert;
+
+namespace SuccincTTests.SuccincT.EnumParsers
+{
+    [TestFixture]
+    public class EnumCharParserTests
+    {
+        private enum TestType
+        {
+            Foo = 'F',
+            Bar = 'B'
+        }
+
+        private enum NotCharType
+        {
+            Foo,
+            Bar
+        }
+
+        private struct JustAStruct
+        {
+
+        }
+
+        [Test]
+        public void NonEnumShouldThrowException()
+        {
+            // GIVEN a char
+
+            // WHEN it is parsed into a type that is not an enum
+            Action action = () =>
+            {
+                'F'.TryParsEnum<JustAStruct>();
+            };
+
+            // THEN an argument exception should be thrown
+            Throws<ArgumentException>(new TestDelegate(action), "an argument exception should have been thrown");
+        }
+
+        [Test]
+        public void EnumNotKeyedToCharShouldReturnNone()
+        {
+            // GIVEN a char
+            // WHEN it is parsed into an enum type that is not keyed to chars
+            var result = 'C'.TryParsEnum<NotCharType>();
+
+            // THEN it should return option none
+            AreEqual(Option<NotCharType>.None(), result, "if the enum is not keyed to chars, it should return none");
+        }
+
+        [Test]
+        public void InvalidValueReturnsNone()
+        {
+            // GIVEN a char
+            // WHEN it is parsed into an enum type that doesn't have a corresponding value
+            var result = 'C'.TryParsEnum<TestType>();
+
+            // THEN it should return option none
+            AreEqual(Option<TestType>.None(),result, "if the char doesn't correspond to an enum value, it should return none");
+        }
+
+        [Test]
+        public void ValidCharReturnsProperEnumValue()
+        {
+            // GIVEN a char
+            // WHEN it is parsed into an enum type with the corresponding char value
+            var result = 'F'.TryParsEnum<TestType>();
+
+            // THEN the corresponding enum value option should be returned
+            AreEqual(Option<TestType>.Some(TestType.Foo), result,
+                "result should have returned some with the correct enum value");
+        }
+
+
+    }
+}


### PR DESCRIPTION
I think this would be a useful addition because of the way that enums mapped to chars are handled. If you think this would be good to have in the library I can clean it up and match style etc.